### PR TITLE
Adds setting to make "Allow Schema Editing" OFF when opening file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
 					"type": "string",
 					"default": "depot.dpo",
 					"description": "Default filename for creating a new Depot file from the command palette"
+				},
+				"depot.openWithSchemaEditingOn": {
+					"type": "boolean",
+					"default": true,
+					"description": "Depot files are opened with schema editing ON."
 				}
 			}
 		},

--- a/src/depotDataEditor.ts
+++ b/src/depotDataEditor.ts
@@ -200,6 +200,9 @@ export class DepotEditorProvider implements vscode.CustomTextEditorProvider {
 		// Use a nonce to whitelist which scripts can be run
 		const nonce = getNonce();
 
+		// get 'openWithSchemaEditingOn' config
+		const openWithSchemaEditingOn = vscode.workspace.getConfiguration('depot').get('openWithSchemaEditingOn');
+
         return /* html */`
         <!DOCTYPE html>
         <html lang="en">
@@ -223,6 +226,7 @@ export class DepotEditorProvider implements vscode.CustomTextEditorProvider {
 			// console.log(${strung});
 			const nonce = "${nonce}";
 			const icons = ${strung};
+			const openWithSchemaEditingOn = ${openWithSchemaEditingOn};
 			const vscode = acquireVsCodeApi();
 		</script>
         </body>

--- a/src/svelte/App.svelte
+++ b/src/svelte/App.svelte
@@ -22,6 +22,7 @@ limitations under the License.
 	onMount(() => {
         setContext("nonce", nonce);
         setContext("iconPaths", icons);
+        setContext("openWithSchemaEditingOn", openWithSchemaEditingOn);
         vscode.postMessage({
             type: 'init-view',
 		});

--- a/src/svelte/Depot/Depot.svelte
+++ b/src/svelte/Depot/Depot.svelte
@@ -28,7 +28,7 @@ let showLineGUIDs = false;
 let previewDisclosedFields = false;
 let showNestedNames = true;
 let showNestedPaths = false;
-let allowSchemaEditing = true;
+let allowSchemaEditing = getContext("openWithSchemaEditingOn");
 let allowAddRemoveItems = true;
 let iconPaths = getContext("iconPaths");
 


### PR DESCRIPTION
To prevent some user errors, it is desireable to have the "Allow Schema
Editing" set to "off". After some discussion with @kkushtel, it was
decided that this could be a setting of the extension.

This development implements that.

Issue #36