### PR TITLE
Fix grid columns not getting clean default values

### DIFF
--- a/src/svelte/Depot/DepotSheet.svelte
+++ b/src/svelte/Depot/DepotSheet.svelte
@@ -162,7 +162,7 @@ function handleSubTableEvent(event) {
                             }
                             else
                             {
-                                newLine[column.name] = column.defaultValue;
+                                newLine[column.name] = Array.isArray(column.defaultValue) ? column.defaultValue.split() : column.defaultValue;
                             }
                         });
                         //if the sheet we clicked add on isn't a props sheet


### PR DESCRIPTION
Makes a copy of the default value for _any_ array type - this is intended for fixing just grid columns, but if there are other array values I am pretty sure this is the correct way to do it anyway. I noticed that when adding lines with a grid column, the new lines were sharing their array reference with the default value and each other until the file was reopened.